### PR TITLE
Fix: Resolve form validation test selector ambiguity (Issue #7)

### DIFF
--- a/apps/web/src/__tests__/integration/form-validation.test.tsx
+++ b/apps/web/src/__tests__/integration/form-validation.test.tsx
@@ -37,7 +37,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Verify default content is present
@@ -45,7 +45,7 @@ describe('Form Validation and Error Handling Integration', () => {
       expect(screen.getByDisplayValue('Add your story description here...')).toBeInTheDocument()
 
       // Save button should be disabled
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
       expect(saveButton).toBeDisabled()
 
       // Try to submit anyway (should not work)
@@ -55,7 +55,7 @@ describe('Form Validation and Error Handling Integration', () => {
       expect(mockStoriesApi.create).not.toHaveBeenCalled()
 
       // Modal should remain open
-      expect(screen.getByText('Edit Story')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
     })
 
     it('should prevent submission with empty title', async () => {
@@ -71,7 +71,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Clear title but keep valid description
@@ -83,7 +83,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.type(descriptionInput, 'Valid description')
 
       // Save button should be disabled due to empty title
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
       expect(saveButton).toBeDisabled()
 
       await user.click(saveButton)
@@ -103,7 +103,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Clear description but keep valid title
@@ -115,7 +115,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.clear(descriptionInput)
 
       // Save button should be disabled due to empty description
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
       expect(saveButton).toBeDisabled()
 
       await user.click(saveButton)
@@ -141,7 +141,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Fill with valid content
@@ -154,7 +154,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.type(descriptionInput, 'Valid description content')
 
       // Save button should be enabled
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
       expect(saveButton).toBeEnabled()
 
       await user.click(saveButton)
@@ -184,12 +184,12 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       const titleInput = screen.getByDisplayValue('New Story')
       const descriptionInput = screen.getByDisplayValue('Add your story description here...')
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
 
       // Initially disabled due to default content
       expect(saveButton).toBeDisabled()
@@ -285,7 +285,7 @@ describe('Form Validation and Error Handling Integration', () => {
 
       const titleInput = screen.getByDisplayValue('TODO Story')
       const descriptionInput = screen.getByDisplayValue('First story description')
-      const storyPointsSelect = screen.getByDisplayValue('3')
+      const storyPointsSelect = screen.getByLabelText('Story Points')
       const saveButton = screen.getByText('Save Changes')
 
       // Test various form interactions
@@ -326,7 +326,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Fill with valid content
@@ -366,7 +366,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Leave default (invalid) content
@@ -381,7 +381,7 @@ describe('Form Validation and Error Handling Integration', () => {
       })
 
       // Modal should remain open
-      expect(screen.getByText('Edit Story')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
     })
 
     it('should handle Escape key properly without validation errors', async () => {
@@ -397,7 +397,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Partially fill form
@@ -410,7 +410,7 @@ describe('Form Validation and Error Handling Integration', () => {
 
       // Modal should close without validation issues
       await waitFor(() => {
-        expect(screen.queryByText('Edit Story')).not.toBeInTheDocument()
+        expect(screen.queryByText('Create Story')).not.toBeInTheDocument()
       })
 
       // No API call should be made
@@ -433,7 +433,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Fill valid content
@@ -446,7 +446,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.type(descriptionInput, 'Valid Description')
 
       // Submit
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: /create story/i })
       await user.click(saveButton)
 
       // Should attempt API call
@@ -455,7 +455,7 @@ describe('Form Validation and Error Handling Integration', () => {
       })
 
       // Modal should remain open due to error
-      expect(screen.getByText('Edit Story')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       expect(screen.getByDisplayValue('Valid Title')).toBeInTheDocument()
     })
 
@@ -499,7 +499,7 @@ describe('Form Validation and Error Handling Integration', () => {
       })
 
       // Modal should remain open with changes preserved
-      expect(screen.getByText('Edit Story')).toBeInTheDocument()
+      expect(screen.getByRole("heading", { name: /edit story/i })).toBeInTheDocument()
       expect(screen.getByDisplayValue('Updated Title')).toBeInTheDocument()
     })
 
@@ -519,7 +519,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: /create story/i })).toBeInTheDocument()
       })
 
       // Fill and submit (will fail)
@@ -531,7 +531,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.clear(descriptionInput)
       await user.type(descriptionInput, 'Valid Description')
 
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole("button", { name: /create story/i })
       await user.click(saveButton)
 
       await waitFor(() => {
@@ -539,7 +539,7 @@ describe('Form Validation and Error Handling Integration', () => {
       })
 
       // Modal should still be open
-      expect(screen.getByText('Edit Story')).toBeInTheDocument()
+      expect(screen.getByRole("heading", { name: /create story/i })).toBeInTheDocument()
 
       // Make a small change and try again
       await user.clear(titleInput)
@@ -555,7 +555,7 @@ describe('Form Validation and Error Handling Integration', () => {
 
       // Should close on success
       await waitFor(() => {
-        expect(screen.queryByText('Edit Story')).not.toBeInTheDocument()
+        expect(screen.queryByRole('heading', { name: /create story/i })).not.toBeInTheDocument()
       })
     })
   })
@@ -580,7 +580,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole("heading", { name: /create story/i })).toBeInTheDocument()
       })
 
       const titleInput = screen.getByDisplayValue('New Story')
@@ -591,7 +591,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.clear(descriptionInput)
       await user.type(descriptionInput, 'Description with tags and symbols')
 
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole("button", { name: /create story/i })
       expect(saveButton).toBeEnabled()
       await user.click(saveButton)
 
@@ -621,7 +621,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole("heading", { name: /create story/i })).toBeInTheDocument()
       })
 
       const titleInput = screen.getByDisplayValue('New Story')
@@ -633,7 +633,7 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.type(descriptionInput, longDescription)
 
       // Should still be valid despite length
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole("button", { name: /create story/i })
       expect(saveButton).toBeEnabled()
     })
 
@@ -650,11 +650,11 @@ describe('Form Validation and Error Handling Integration', () => {
       await user.click(addButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole("heading", { name: /create story/i })).toBeInTheDocument()
       })
 
       const titleInput = screen.getByDisplayValue('New Story')
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole("button", { name: /create story/i })
 
       // Rapid changes
       await user.clear(titleInput)


### PR DESCRIPTION
## Summary
- 🐛 Fixed selector issues in `form-validation.test.tsx` that were causing test failures
- ✅ All 16 tests now passing (previously only 2 were passing)
- 🎯 Implemented semantic, accessible selectors that are more robust

## Problem Description
The test `should maintain validation state across form interactions` and others were failing due to selector ambiguity issues. The tests were looking for "Edit Story" text in modal headers and "Save Changes" buttons, but when creating new stories (draft stories), the modal shows:
- Header: "Create Story" (for draft stories with IDs starting with "draft-")
- Button: "Create Story" (instead of "Save Changes")

## Root Cause
As analyzed in Issue #7, the selector issue was not actually a validation state problem but a test implementation issue where:
- `screen.getByTitle('Edit story')` was matching multiple elements (3 story cards = 3 edit buttons)
- Modal text differed between creation ("Create Story") and editing ("Edit Story") modes
- Tests weren't distinguishing between these two scenarios

## Solution Implemented
1. **Used semantic role-based selectors** with regex for case-insensitive matching:
   - `getByRole('heading', { name: /create story/i })` for modal headers
   - `getByRole('button', { name: /create story/i })` for submit buttons

2. **Fixed story points selector** to use semantic label association:
   - Changed from `getByDisplayValue('3')` to `getByLabelText('Story Points')`

3. **Distinguished between creation and editing tests**:
   - Creation tests now correctly expect "Create Story" text
   - Editing tests continue to expect "Edit Story" and "Save Changes"

## Test Results
```
✓ All 16 tests passing
✓ No regressions
✓ Tests run in ~6 seconds
```

## Files Changed
- `apps/web/src/__tests__/integration/form-validation.test.tsx`

## Testing
- Ran the specific failing test to verify it passes
- Ran the entire test suite for the file to ensure no regressions
- All form validation functionality continues to work as expected

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)