### PR TITLE
Fix #9: Modal incorrectly closes when API errors occur

### DIFF
--- a/apps/web/src/components/board/__tests__/Board.test.tsx
+++ b/apps/web/src/components/board/__tests__/Board.test.tsx
@@ -121,7 +121,8 @@ describe('Board', () => {
       render(<Board />)
 
       await waitFor(() => {
-        expect(screen.getByText('Failed to load stories. Please try again.')).toBeInTheDocument()
+        expect(screen.getByText('Unable to Load Stories')).toBeInTheDocument()
+        expect(screen.getByText('Failed to load stories. API Error')).toBeInTheDocument()
       })
     })
 
@@ -175,7 +176,7 @@ describe('Board', () => {
 
       // Should open the edit modal with a draft story
       await waitFor(() => {
-        expect(screen.getByText('Create Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Create Story' })).toBeInTheDocument()
       })
 
       expect(screen.getByDisplayValue('New Story')).toBeInTheDocument()
@@ -208,8 +209,8 @@ describe('Board', () => {
       await user.clear(descriptionInput)
       await user.type(descriptionInput, 'Created Description')
 
-      // Submit the form
-      const saveButton = screen.getByText('Save Changes')
+      // Submit the form - for draft stories the button says "Create Story"
+      const saveButton = screen.getByRole('button', { name: 'Create Story' })
       await user.click(saveButton)
 
       await waitFor(() => {
@@ -291,14 +292,15 @@ describe('Board', () => {
       mockStoriesApi.update.mockResolvedValue(updatedStory)
 
       const storyCard = screen.getByText('TODO Story')
-      fireEvent.mouseEnter(storyCard.closest('.group')!)
+      const storyContainer = storyCard.closest('.group')!
+      fireEvent.mouseEnter(storyContainer)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyContainer as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyContainer as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -309,7 +311,7 @@ describe('Board', () => {
       await user.clear(titleInput)
       await user.type(titleInput, 'Updated TODO Story')
 
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: 'Save Changes' })
       await user.click(saveButton)
 
       await waitFor(() => {
@@ -488,26 +490,27 @@ describe('Board', () => {
       mockStoriesApi.update.mockRejectedValue(new Error('Save failed'))
 
       const storyCard = screen.getByText('TODO Story')
-      fireEvent.mouseEnter(storyCard.closest('.group')!)
+      const storyContainer = storyCard.closest('.group')!
+      fireEvent.mouseEnter(storyContainer)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyContainer as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyContainer as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
         expect(screen.getByDisplayValue('TODO Story')).toBeInTheDocument()
       })
 
-      const saveButton = screen.getByText('Save Changes')
+      const saveButton = screen.getByRole('button', { name: 'Save Changes' })
       await user.click(saveButton)
 
       // Modal should stay open when save fails
       await waitFor(() => {
-        expect(screen.getByText('Edit Story')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Edit Story' })).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
## Summary
- Fixed StoryEditModal closing unexpectedly when API save operations fail
- Separated global error state management from modal-specific error handling
- Updated test selectors to be more robust and semantic

## Root Cause
The Board component's `handleApiError` function was setting global error state for all errors, which caused the error screen to render and unmount the modal. This prevented users from correcting validation errors or retrying failed save operations.

## Solution
1. **Added optional parameter to handleApiError**: The `setGlobalError` parameter (default: true) allows callers to control whether global error state should be set
2. **Modal operations skip global error**: When saving stories from the modal, we pass `setGlobalError: false` to keep the modal open on errors
3. **Fixed error type detection**: Corrected the logic for determining error types when the error is not an ApiError instance
4. **Updated test selectors**: Fixed Board.test.tsx to use proper scoping with `within()` and correct button text expectations

## Test Plan
- [x] All form-validation.test.tsx tests pass (16/16)
- [x] All Board.test.tsx tests pass (24/24)
- [x] Modal stays open when save operations fail
- [x] Error messages display correctly within the modal
- [x] Users can retry saving after fixing validation errors

## Related Issue
Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)