### PR TITLE
Fix: Resolve test selector issues for story buttons (issue #12)

### DIFF
--- a/apps/web/src/components/story/__tests__/StoryCard.test.tsx
+++ b/apps/web/src/components/story/__tests__/StoryCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StoryCard } from '../StoryCard'
 import { createMockStory } from '@/__tests__/utils/test-utils'
@@ -158,27 +158,31 @@ describe('StoryCard', () => {
     it('should render edit button when onEdit prop is provided', () => {
       render(<StoryCard story={defaultStory} onEdit={mockOnEdit} />)
 
-      const editButton = screen.getByTitle('Edit story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const editButton = within(storyCard).getByTitle('Edit story')
       expect(editButton).toBeInTheDocument()
     })
 
     it('should render delete button when onDelete prop is provided', () => {
       render(<StoryCard story={defaultStory} onDelete={mockOnDelete} />)
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const deleteButton = within(storyCard).getByTitle('Delete story')
       expect(deleteButton).toBeInTheDocument()
     })
 
     it('should not render edit button when onEdit prop is not provided', () => {
       render(<StoryCard story={defaultStory} />)
 
-      expect(screen.queryByTitle('Edit story')).not.toBeInTheDocument()
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      expect(within(storyCard).queryByTitle('Edit story')).not.toBeInTheDocument()
     })
 
     it('should not render delete button when onDelete prop is not provided', () => {
       render(<StoryCard story={defaultStory} />)
 
-      expect(screen.queryByTitle('Delete story')).not.toBeInTheDocument()
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      expect(within(storyCard).queryByTitle('Delete story')).not.toBeInTheDocument()
     })
   })
 
@@ -187,7 +191,8 @@ describe('StoryCard', () => {
       const user = userEvent.setup()
       render(<StoryCard story={defaultStory} onEdit={mockOnEdit} />)
 
-      const editButton = screen.getByTitle('Edit story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const editButton = within(storyCard).getByTitle('Edit story')
       await user.click(editButton)
 
       expect(mockOnEdit).toHaveBeenCalledWith(defaultStory)
@@ -197,7 +202,8 @@ describe('StoryCard', () => {
       const user = userEvent.setup()
       render(<StoryCard story={defaultStory} onDelete={mockOnDelete} />)
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const deleteButton = within(storyCard).getByTitle('Delete story')
       await user.click(deleteButton)
 
       expect(mockOnDelete).toHaveBeenCalledWith(defaultStory)
@@ -213,7 +219,8 @@ describe('StoryCard', () => {
         </div>
       )
 
-      const editButton = screen.getByTitle('Edit story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const editButton = within(storyCard).getByTitle('Edit story')
       await user.click(editButton)
 
       expect(mockOnEdit).toHaveBeenCalled()
@@ -230,7 +237,8 @@ describe('StoryCard', () => {
         </div>
       )
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const deleteButton = within(storyCard).getByTitle('Delete story')
       await user.click(deleteButton)
 
       expect(mockOnDelete).toHaveBeenCalled()
@@ -293,7 +301,8 @@ describe('StoryCard', () => {
     it('should show action buttons on hover through CSS classes', () => {
       render(<StoryCard story={defaultStory} onEdit={mockOnEdit} onDelete={mockOnDelete} />)
 
-      const actionContainer = screen.getByTitle('Edit story').parentElement!
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const actionContainer = within(storyCard).getByTitle('Edit story').parentElement!
       expect(actionContainer).toHaveClass('opacity-0')
       expect(actionContainer).toHaveClass('group-hover:opacity-100')
     })
@@ -311,8 +320,9 @@ describe('StoryCard', () => {
     it('should have proper button types for action buttons', () => {
       render(<StoryCard story={defaultStory} onEdit={mockOnEdit} onDelete={mockOnDelete} />)
 
-      const editButton = screen.getByTitle('Edit story')
-      const deleteButton = screen.getByTitle('Delete story')
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      const editButton = within(storyCard).getByTitle('Edit story')
+      const deleteButton = within(storyCard).getByTitle('Delete story')
 
       expect(editButton).toHaveAttribute('type', 'button')
       expect(deleteButton).toHaveAttribute('type', 'button')
@@ -321,8 +331,9 @@ describe('StoryCard', () => {
     it('should have proper title attributes for action buttons', () => {
       render(<StoryCard story={defaultStory} onEdit={mockOnEdit} onDelete={mockOnDelete} />)
 
-      expect(screen.getByTitle('Edit story')).toBeInTheDocument()
-      expect(screen.getByTitle('Delete story')).toBeInTheDocument()
+      const storyCard = screen.getByText('Test Story Title').closest('.group') as HTMLElement
+      expect(within(storyCard).getByTitle('Edit story')).toBeInTheDocument()
+      expect(within(storyCard).getByTitle('Delete story')).toBeInTheDocument()
     })
   })
 

--- a/tests/api-error-handling.test.tsx
+++ b/tests/api-error-handling.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Board } from '@/components/board/Board'
 import { StoryEditModal } from '@/components/modals/StoryEditModal'
@@ -182,11 +182,11 @@ describe('API Error Handling Comprehensive Tests', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -269,11 +269,11 @@ describe('API Error Handling Comprehensive Tests', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -352,11 +352,11 @@ describe('API Error Handling Comprehensive Tests', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -395,11 +395,11 @@ describe('API Error Handling Comprehensive Tests', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const deleteButton = screen.getByTitle('Delete story')
+        const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
         expect(deleteButton).toBeInTheDocument()
       })
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
       await user.click(deleteButton)
 
       await waitFor(() => {

--- a/tests/error-message-display.test.tsx
+++ b/tests/error-message-display.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Board } from '@/components/board/Board'
 import { createMockStory } from '@/__tests__/utils/test-utils'
@@ -183,11 +183,11 @@ describe('Error Message Display and User Communication', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -228,11 +228,11 @@ describe('Error Message Display and User Communication', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const deleteButton = screen.getByTitle('Delete story')
+        const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
         expect(deleteButton).toBeInTheDocument()
       })
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
       await user.click(deleteButton)
 
       await waitFor(() => {

--- a/tests/performance-error-testing.test.tsx
+++ b/tests/performance-error-testing.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Board } from '@/components/board/Board'
 import { createMockStory } from '@/__tests__/utils/test-utils'
@@ -489,11 +489,11 @@ describe('Performance and Load Testing for Error Scenarios', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {

--- a/tests/retry-mechanism-testing.test.tsx
+++ b/tests/retry-mechanism-testing.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Board } from '@/components/board/Board'
 import { createMockStory } from '@/__tests__/utils/test-utils'
@@ -272,11 +272,11 @@ describe('Retry Mechanism and Recovery Testing', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const editButton = screen.getByTitle('Edit story')
+        const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
         expect(editButton).toBeInTheDocument()
       })
 
-      const editButton = screen.getByTitle('Edit story')
+      const editButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Edit story')
       await user.click(editButton)
 
       await waitFor(() => {
@@ -542,11 +542,11 @@ describe('Retry Mechanism and Recovery Testing', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const deleteButton = screen.getByTitle('Delete story')
+        const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
         expect(deleteButton).toBeInTheDocument()
       })
 
-      const deleteButton = screen.getByTitle('Delete story')
+      const deleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
       await user.click(deleteButton)
 
       await waitFor(() => {
@@ -567,7 +567,7 @@ describe('Retry Mechanism and Recovery Testing', () => {
       fireEvent.mouseEnter(storyCard.closest('.group')!)
 
       await waitFor(() => {
-        const retryDeleteButton = screen.getByTitle('Delete story')
+        const retryDeleteButton = within(storyCard.closest('.group') as HTMLElement).getByTitle('Delete story')
         expect(retryDeleteButton).toBeInTheDocument()
       })
 


### PR DESCRIPTION
## Summary
- Fixed "Found multiple elements" test failures by properly scoping selectors
- Applied consistent pattern using `within()` to scope button queries to their parent container
- Resolves issue #12 as described in the GitHub issue

## Changes Made
- Updated 5 test files to use properly scoped selectors for Edit/Delete story buttons
- Replaced `screen.getByTitle('Edit story')` with `within(storyCard.closest('.group')).getByTitle('Edit story')`
- Fixed similar issues with Delete story button selectors

## Test Results
✅ The specific failing test mentioned in issue #12 (`should save story changes when form is submitted`) now passes
✅ All Board.test.tsx tests pass (24 tests)
✅ All StoryCard.test.tsx tests pass (32 tests)

## Files Modified
- `apps/web/src/components/story/__tests__/StoryCard.test.tsx`
- `tests/api-error-handling.test.tsx`
- `tests/error-message-display.test.tsx`
- `tests/performance-error-testing.test.tsx`
- `tests/retry-mechanism-testing.test.tsx`

## Technical Details
The issue was caused by tests using global `screen.getByTitle()` queries when multiple story cards were rendered, causing "Found multiple elements with the title: Edit story" errors. The fix ensures each button query is scoped to its specific story card container using React Testing Library's `within()` utility.

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)