### PR TITLE
Fix: Story Editing Modal Form Initialization Issue (#19)

### DIFF
--- a/apps/web/src/__tests__/integration/story-workflows.test.tsx
+++ b/apps/web/src/__tests__/integration/story-workflows.test.tsx
@@ -238,7 +238,13 @@ describe('Story Workflows Integration', () => {
       // Step 4: Modify the form
       const titleInput = screen.getByDisplayValue('TODO Story')
       const descriptionInput = screen.getByDisplayValue('First story description')
-      const storyPointsSelect = screen.getByDisplayValue('3')
+
+      // Wait for story points select to be populated
+      const storyPointsSelect = await waitFor(() => {
+        const select = screen.getByLabelText(/Story Points/i) as HTMLSelectElement
+        expect(select.value).toBe('3')
+        return select
+      }, { timeout: 2000 })
       const assigneeInput = screen.getByDisplayValue('')
 
       await user.clear(titleInput)

--- a/apps/web/src/components/modals/StoryEditModal.tsx
+++ b/apps/web/src/components/modals/StoryEditModal.tsx
@@ -304,16 +304,16 @@ export function StoryEditModal({
                   </label>
                   <select
                     id="storyPoints"
-                    value={formData.storyPoints || story?.storyPoints || 1}
+                    value={String(formData.storyPoints ?? story?.storyPoints ?? 1)}
                     onChange={e => handleInputChange('storyPoints', parseInt(e.target.value))}
                     className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-slate-900 bg-white"
                   >
-                    <option value={1}>1 point</option>
-                    <option value={2}>2 points</option>
-                    <option value={3}>3 points</option>
-                    <option value={5}>5 points</option>
-                    <option value={8}>8 points</option>
-                    <option value={13}>13 points</option>
+                    <option value="1">1 point</option>
+                    <option value="2">2 points</option>
+                    <option value="3">3 points</option>
+                    <option value="5">5 points</option>
+                    <option value="8">8 points</option>
+                    <option value="13">13 points</option>
                     <option value={21}>21 points</option>
                   </select>
                 </div>


### PR DESCRIPTION
## Summary

This PR fixes issue #19 where the story editing modal was not correctly displaying existing story values, particularly story points. The root cause was a JavaScript operator precedence issue combined with async test timing problems.

## Problem

The StoryEditModal component was using the logical OR (`||`) operator for default value fallbacks:
```javascript
value={formData.storyPoints || story?.storyPoints || 1}
```

This treats all falsy values (including `0` and empty strings) as "unset", causing the form to show the default value `1` instead of the story's actual value (e.g., `3` story points).

## Solution

1. **Changed logical OR to nullish coalescing operator (`??`)** in StoryEditModal.tsx:
   ```javascript
   value={String(formData.storyPoints ?? story?.storyPoints ?? 1)}
   ```
   The nullish coalescing operator only fallbacks on `null` or `undefined`, not falsy values.

2. **Updated select element to use string values** for proper React compatibility
3. **Enhanced test assertions** with proper async handling using `waitFor`

## Testing

- ✅ Story editing workflow test now passes
- ✅ Story points correctly display existing values
- ✅ Form validation works as expected
- ✅ No regressions introduced in other test suites

## Test Results

```
Story Workflows Integration
  Complete Story Editing Workflow
    ✓ should handle the complete flow: click edit -> modify -> save
    ✓ should handle edit cancellation
    ✓ should handle save errors gracefully
```

## Related

- Fixes #19
- Based on the comprehensive hive mind analysis in the issue comments

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests have been updated and pass
- [x] No new warnings or errors introduced
- [x] Changes are backwards compatible

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>