### PR TITLE
fix: resolve DeleteConfirmationModal async test failure (issue #22)

### DIFF
--- a/apps/web/src/components/modals/__tests__/DeleteConfirmationModal.test.tsx
+++ b/apps/web/src/components/modals/__tests__/DeleteConfirmationModal.test.tsx
@@ -9,7 +9,7 @@ describe('DeleteConfirmationModal', () => {
   setupModalTestEnvironment()
 
   const mockOnClose = jest.fn()
-  const mockOnConfirm = jest.fn()
+  const mockOnConfirm = jest.fn().mockResolvedValue(undefined)
   const mockStory = createMockStory({
     title: 'Story to Delete',
     description: 'This story will be deleted',
@@ -216,8 +216,10 @@ describe('DeleteConfirmationModal', () => {
       const deleteButton = screen.getByRole('button', { name: 'Delete Story' })
       await user.click(deleteButton)
 
-      expect(mockOnConfirm).toHaveBeenCalled()
-      expect(mockOnClose).toHaveBeenCalled()
+      await waitFor(() => {
+        expect(mockOnConfirm).toHaveBeenCalled()
+        expect(mockOnClose).toHaveBeenCalled()
+      })
     })
 
     it('should call onClose when cancel button is clicked', async () => {


### PR DESCRIPTION
## Summary

This PR fixes the failing test for the DeleteConfirmationModal component that was blocking validation of the critical deletion cancellation safety feature.

## Problem

The test `should call onConfirm and onClose when delete button is clicked` was failing because:
- The `mockOnConfirm` mock function wasn't returning a promise
- When the modal's `handleConfirm` function called `await onConfirm()`, it couldn't properly await the async operation
- The test would check for `onClose` being called before the async operation completed

## Solution

- Updated `mockOnConfirm` to return a resolved promise using `jest.fn().mockResolvedValue(undefined)`
- Added `waitFor` wrapper in the test to properly handle the async operation
- This ensures the test correctly validates that both callbacks are called in sequence

## Technical Details

The modal implementation was already correct - it properly:
1. Calls `onConfirm` first (awaiting the result)
2. Then calls `onClose` after successful deletion
3. Keeps the modal open if an error occurs (proper error handling)

This fix simply aligns the test expectations with the actual async behavior of the component.

## Test Results

All 23 tests in the DeleteConfirmationModal test suite now pass:
- ✅ Modal Rendering tests
- ✅ Story Preview tests
- ✅ Warning Messages tests
- ✅ Actions tests (including the fixed async test)
- ✅ Keyboard Interactions tests
- ✅ Modal Interactions tests
- ✅ Button States tests
- ✅ Accessibility tests

## Impact

This fix validates that the critical safety feature for deletion cancellation works correctly, preventing accidental data loss for users.

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)